### PR TITLE
added support for other models (eg: deepseek r1)

### DIFF
--- a/descriptors/default/t2sql_descriptor.json
+++ b/descriptors/default/t2sql_descriptor.json
@@ -1,22 +1,17 @@
 {
   "router_model_list": [
     {
-      "model_name": "gpt-4o",
+      "model_name": "deepseek_r1",
       "litellm_params": {
-        "model": "gpt-4o",
-        "api_key": "<your api key goes here>"
-      }
-    },
-    {
-      "model_name": "o3-mini",
-      "litellm_params": {
-        "model": "o3-mini",
-        "api_key": "<your api key goes here>"
+          "model": "fireworks_ai/accounts/fireworks/models/deepseek-r1",
+          "api_key": "<your api key goes here>"
       }
     }
   ],
   "open_ai_key": "<your api key goes here>",
-  "model": "gpt-4o",
+  "model_sql": "deepseek_r1",
+  "model_table_selection": "deepseek_r1",
+  "model_supports_reasoning": false,
   "descriptors_path": "descriptors/default",
   "docs_md_folder": "training_data_storage/md_docs",
   "docs_json_folder": "training_data_storage/json_docs",

--- a/t2sql/controller/make_answer.py
+++ b/t2sql/controller/make_answer.py
@@ -6,7 +6,9 @@ from t2sql.base import BaseText2SQLAgent
 async def make_answer(query: str, agent: BaseText2SQLAgent) -> str:
     logger.info(f"[{agent._descriptor_folder}] Extracting sql for query: {query}...")
 
-    sql, _ = await agent.make_sql(query)
+    sql, _ = await agent.make_sql(query,
+                                  reasoning_model_sql=agent.config.get("model_sql"),
+                                  reasoning_model_table=agent.config.get("model_table_selection"))
 
     logger.info(f"[{agent._descriptor_folder}] Generated sql: {sql}")
 


### PR DESCRIPTION
**Summary**

This update allows you to configure any model for SQL generation and table selection independently.

**Changes**
- Support for custom models in:
- model_sql — used for SQL generation
- model_table_selection — used for selecting relevant tables
- Both reasoning and non-reasoning models are now supported.
- To use a custom model, add it to the router_model_list in descriptor.json and set the corresponding fields (model_sql, model_table_selection).

**Tested with**
- Fireworks/DeepSeek R1
- OpenAI/O3-mini
